### PR TITLE
feat: Add attribute to panel and state to be able to suppress busy animation overlay

### DIFF
--- a/packages/web/src/store/panel.ts
+++ b/packages/web/src/store/panel.ts
@@ -10,12 +10,15 @@ export class StorePanel extends MobxLitElement {
     @property({ type: String, attribute: 'loading-message' })
     loadingMessage
 
+    @property({ type: Boolean, attribute: 'no-busy' })
+    noBusy
+
     render() {
         if (!this.store)
             return ''
 
         return html`
-            <c6o-store-state loading-message=${this.loadingMessage} .store=${this.store}>
+            <c6o-store-state loading-message=${this.loadingMessage} ?no-busy=${this.noBusy} .store=${this.store}>
                 <slot></slot>
                 ${this.store.nullState ? html`
                     <slot name="null"></slot>

--- a/packages/web/src/store/state.ts
+++ b/packages/web/src/store/state.ts
@@ -18,6 +18,9 @@ export class StoreState extends MobxLitElement {
     @property({ type: String, attribute: 'loading-message' })
     loadingMessage
 
+    @property({ type: Boolean, attribute: 'no-busy' })
+    noBusy = false
+
     static get styles(): (CSSResult[] | CSSResult)[] {
         return [
             cssReboot,
@@ -69,7 +72,7 @@ export class StoreState extends MobxLitElement {
         if (this.store?.initialized) {
             return html`
                 <section id="content">
-                    <div id="overlay" class="${this.store.busy ? 'busy' : ''}"></div>
+                    <div id="overlay" class="${this.store.busy && !this.noBusy ? 'busy' : ''}"></div>
                     <slot></slot>
                 </section>
             `


### PR DESCRIPTION
## Description

We don't want the busy animation overlay when filtering grids as it's too distracting.